### PR TITLE
Write output with explicit UTF-8 encoding

### DIFF
--- a/flext.py
+++ b/flext.py
@@ -912,7 +912,7 @@ def generate_source(argsstring, options, version, enums, functions_by_category, 
 
         allFiles += 1
 
-        with open(outfile, 'w') as out:
+        with open(outfile, 'w', encoding='utf-8') as out:
             out.write(template.render(template_namespace))
             print("Successfully generated %s" % outfile)
             generatedFiles += 1;


### PR DESCRIPTION
On Windows the encoding seems to default to one of the 8-bit code pages instead of UTF-8, noticable with special characters in the header. Python 3.15 supposedly will force the default to be UTF-8 on all platforms, but that's a long way off and won't help on older versions.